### PR TITLE
Adds content image management to articles

### DIFF
--- a/src/app/admin/articles/(actions)/delete-content-image.ts
+++ b/src/app/admin/articles/(actions)/delete-content-image.ts
@@ -1,0 +1,78 @@
+'use server';
+
+import { revalidatePath } from "next/cache";
+import prisma from "@/lib/prisma";
+import deleteImage from "./delete-image.action";
+
+type DeleteContentImageResponse = {
+  ok: boolean;
+  message: string;
+  images?: string[];
+};
+
+export const deleteContentImageAction = async (
+  articleId: string,
+  publicImageUrl: string,
+): Promise<DeleteContentImageResponse> => {
+  const article = await prisma.article.findUnique({
+    where: { id: articleId },
+    select: {
+      id: true,
+      images: true,
+      category: {
+        select: {
+          slug: true,
+        },
+      },
+      slug: true,
+    },
+  });
+
+  if (!article) {
+    return {
+      ok: false,
+      message: '¡ El articulo no existe !',
+    };
+  }
+
+  if (article.images.length === 0) {
+    return {
+      ok: false,
+      message: '¡ No hay imágenes para eliminar !',
+    };
+  }
+
+  const filteredImages = article.images.filter((image: string) => {
+    return image !== publicImageUrl;
+  });
+
+  await prisma.article.update({
+    where: { id: articleId },
+    data: {
+      images: {
+        set: filteredImages,
+      },
+    },
+  });
+
+  // Delete the image using the public ID
+  if (publicImageUrl.startsWith("https://")) {
+    const segments = publicImageUrl.split("/");
+    const folder = segments[segments.length - 2];
+    const imageId = segments[segments.length - 1].replace('.jpg', '');
+    const publicId = `${folder}/${imageId}`;
+    await deleteImage(publicId); 
+  }
+
+  revalidatePath(`/${article!.category?.slug}/${article.slug}`);
+  revalidatePath(`/admin/articles/${article.id}`);
+  revalidatePath(`/admin/articles/${article.id}/edit`);
+
+  return {
+    ok: true,
+    message: 'La imagen del contenido ha sido eliminada 👍',
+    images: filteredImages,
+  };
+};
+
+export default deleteContentImageAction;

--- a/src/app/admin/articles/(actions)/delete-image.action.ts
+++ b/src/app/admin/articles/(actions)/delete-image.action.ts
@@ -5,6 +5,18 @@ import { v2 as cloudinary } from "cloudinary";
 
 cloudinary.config(process.env.CLOUDINARY_URL ?? '');
 
+/**
+ * Eliminates an image from Cloudinary.
+ * @param publicId The public ID of the image to delete from Cloudinary.
+ * This is typically the path to the image without the file extension.
+ * For example, if the image URL is:
+ * `https://res.cloudinary.com/acount_name/image/upload/v3857362705/articles/12f23f85-eeba-4569-8de2-3dce913e0ccb.jpg`\n
+ * `articles/12f23f85-eeba-4569-8de2-3dce913e0ccb` is the public ID.
+ * @example ```typescript
+ * deleteImage("articles/12f23f85-eeba-4569-8de2-3dce913e0ccb");
+ * ```
+ * @returns 
+ */
 const deleteImage = async (publicId: string): Promise<{ ok: boolean }> => {
   try {
     await cloudinary.uploader.destroy(publicId);

--- a/src/app/admin/articles/(actions)/fetch-article.action.ts
+++ b/src/app/admin/articles/(actions)/fetch-article.action.ts
@@ -44,6 +44,7 @@ export const fetchArticleAction = async (articleId: string): Promise<FetchArticl
         },
         imageURL: article.imageURL,
         imageAlt: article.imageAlt,
+        images: article.images,
         author: {
           id: article.author.id,
           name: article.author.name!,

--- a/src/app/admin/articles/(components)/md-editor-field.component.tsx
+++ b/src/app/admin/articles/(components)/md-editor-field.component.tsx
@@ -10,13 +10,20 @@ import uploadContentImage from "../(actions)/upload-content-image.action";
 type Props = Readonly<{
   value: string;
   setContent: (value: string) => void;
+  updateContentImage: (imageUrl: string) => void;
   articleId?: string;
 }>;
 
-export const MdEditorField: FC<Props> = ({ value, setContent, articleId }) => {
+export const MdEditorField: FC<Props> = ({
+  value,
+  setContent,
+  updateContentImage,
+  articleId
+}) => {
   const handleImageUpload = async (file: File) => {
     const response = await uploadContentImage(file, articleId!);
     if (!response?.imageURL) throw new Error("No image URL returned");
+    updateContentImage(response.imageURL);
     return response.imageURL;
   };
 

--- a/src/app/admin/articles/[id]/styles.css
+++ b/src/app/admin/articles/[id]/styles.css
@@ -1,4 +1,0 @@
-td, th {
-  word-break: break-word;
-  white-space: pre-line;
-}

--- a/src/interfaces/article.interface.ts
+++ b/src/interfaces/article.interface.ts
@@ -10,6 +10,7 @@ export interface Article {
   imageURL: string | null;
   imageAlt: string | null;
   imagePublicID?: string;
+  images?: string[];
   slug: string;
   description: string;
   content: string;


### PR DESCRIPTION
Enables the management of content images within articles.

Adds functionality to display thumbnails of images added to the content editor in markdown.
Implements the ability to remove images from the article's image array in the database and from Cloudinary when the remove icon is clicked.
