### PR TITLE
Fixes OpenGraph metadata generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonusbeat-blog",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/(public)/(actions)/fetch-article-metadata.ts
+++ b/src/app/(public)/(actions)/fetch-article-metadata.ts
@@ -5,7 +5,7 @@ type Metadata = {
   seoDescription: string;
   seoRobots: string;
   author: { name: string };
-  publishedAt: Date;
+  publishedAt: Date | null;
   imageUrl: string;
   category: { slug: string };
 };
@@ -31,7 +31,7 @@ export const getArticleMetadataBySlug = async (slug: string): Promise<ResponseFe
           select: { slug: true }
         }
       }
-    }) as Metadata | null;
+    });
 
     if (!metadata) {
       return {
@@ -43,7 +43,19 @@ export const getArticleMetadataBySlug = async (slug: string): Promise<ResponseFe
 
     return {
       ok: true,
-      metadata,
+      metadata: {
+        seoTitle: metadata.seoTitle as string,
+        seoDescription: metadata.seoDescription as string,
+        seoRobots: metadata.seoRobots as string,
+        author: {
+          name: metadata.author.name as string
+        },
+        publishedAt: metadata.publishedAt,
+        imageUrl: metadata.imageURL as string,
+        category: {
+          slug: metadata.category?.slug as string
+        }
+      },
       message: "Article fetched successfully 👍",
     };
   } catch(error) {

--- a/src/app/[category]/[slug]/page.tsx
+++ b/src/app/[category]/[slug]/page.tsx
@@ -37,9 +37,10 @@ export const generateMetadata = async ({ params }: Props): Promise<Metadata> => 
     openGraph: {
       title: metaTitle,
       description: metaDescription,
+      type: "article",
       siteName: "Sonusbeat Blog",
       locale: "es_MX",
-      publishedTime: (metadata?.publishedAt as Date).toISOString(),
+      publishedTime: metadata?.publishedAt?.toISOString(),
       authors: [metadata?.author.name as string],
       images: [`/${metadata?.category.slug}/${metadata?.imageUrl}`],
     },


### PR DESCRIPTION
Ensures correct OpenGraph metadata generation by explicitly casting metadata values and handling potential null values for `publishedAt`. This prevents errors in social media previews and improves SEO.

Also, this commit bumps the package version.