### PR TITLE
Ensures correct image URL generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonusbeat-blog",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/[category]/[slug]/page.tsx
+++ b/src/app/[category]/[slug]/page.tsx
@@ -42,7 +42,11 @@ export const generateMetadata = async ({ params }: Props): Promise<Metadata> => 
       locale: "es_MX",
       publishedTime: metadata?.publishedAt?.toISOString(),
       authors: [metadata?.author.name as string],
-      images: [`/${metadata?.category.slug}/${metadata?.imageUrl}`],
+      images: [
+        metadata?.imageUrl?.startsWith("https")
+          ? metadata?.imageUrl
+          : `/${metadata?.category.slug}/${metadata?.imageUrl}`,
+      ],
     },
   }
 };


### PR DESCRIPTION
Handles image URLs that start with "https" by using them directly,
otherwise constructs the URL using the category slug. This ensures that
external image URLs are used as is and internal URLs are generated correctly.