### PR TITLE
Fixes category form default translation values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonusbeat-blog",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/admin/categories/(components)/category-form.component.tsx
+++ b/src/app/admin/categories/(components)/category-form.component.tsx
@@ -38,23 +38,15 @@ export const CategoryForm: FC<Props> = ({ category }) => {
     defaultValues: {
       name: category ? category.name : "",
       slug: category ? category.slug : "",
-      translations: (category && category.translations)
-        ? category?.translations.map((t) => ({
+      translations: (category && category.translations && category.translations.length > 0)
+        ? category.translations.map((t) => ({
           name: t.name,
           slug: t.slug,
           language: t.language,
         }))
         : [
-          {
-            name: "",
-            slug: "",
-            language: "es",
-          },
-          {
-            name: "",
-            slug: "",
-            language: "en",
-          },
+          { name: "", slug: "", language: "es", },
+          { name: "", slug: "", language: "en", },
         ],
     },
   });
@@ -171,7 +163,10 @@ export const CategoryForm: FC<Props> = ({ category }) => {
                   name={`translations.${index}.slug`}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Slug</FormLabel>
+                      <FormLabel>
+                        {(fields[index].language === "es") && "Enlace Permanente"}
+                        {(fields[index].language === "en") && "Slug"}
+                      </FormLabel>
                       <FormControl>
                         <Input {...field} />
                       </FormControl>


### PR DESCRIPTION
Ensures that the category form correctly initializes translation fields when a category is loaded for editing, avoiding potential errors.

Updates the category form to display "Enlace Permanente" label for Spanish slug.

Increments package version.