### PR TITLE
Adds pagination to public articles list

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -18,5 +18,9 @@
     "email": "Email",
     "password": "Password",
     "loginButton": "Login"
+  },
+  "Pagination": {
+    "next": "Next",
+    "prev": "Previous"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -18,5 +18,9 @@
     "email": "Correo Electrónico",
     "password": "Contraseña",
     "loginButton": "Iniciar Sesión"
+  },
+  "Pagination": {
+    "next": "Siguientes",
+    "prev": "Anteriores"
   }
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
     serverActions: {
       bodySizeLimit: '2mb',
     },
+    useCache: true,
   },
   images: {
     remotePatterns: [

--- a/src/app/(public)/components/article-list.component.tsx
+++ b/src/app/(public)/components/article-list.component.tsx
@@ -7,7 +7,7 @@ type Props = Readonly<{
   locale: string;
 }>;
 
-export const ArticlesList: FC<Props> = async ({ articles, locale }) => {
+export const ArticlesList: FC<Props> = async ({ articles, locale }) => {  
   const filteredArticles = articles.filter(article => {
     const hasArticleTranslation = article.translations.some(t => t.language === locale);
     const hasCategoryTranslation = article.category.translations?.some(t => t.language === locale);

--- a/src/app/(public)/components/pagination/pagination.component.tsx
+++ b/src/app/(public)/components/pagination/pagination.component.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { FC } from 'react';
+import { redirect, usePathname, useSearchParams } from 'next/navigation';
+import { generatePaginationNumbers } from '@/lib/generate-pagination-numbers';
+import styles from './styles.module.css';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+
+type Props = Readonly<{
+  totalPages: number;
+}>;
+
+export const PublicPagination: FC<Props> = ({ totalPages }) => {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const pageString = searchParams.get('page') ?? '1';
+  const currentPage = isNaN(+pageString) ? 1 : +pageString;
+  const allPages = generatePaginationNumbers(currentPage, totalPages);
+  const translate = useTranslations('Pagination');
+
+  if (currentPage < 1 || isNaN(+pageString)) {
+    redirect(pathname);
+  }
+
+  const createPageUrl = (pageNumber: number | string) => {
+    const params = new URLSearchParams(searchParams);
+
+    if (pageNumber === '...') {
+      // example: "/admin/articles?page=1"
+      return `${pathname}${params.toString()}`;
+    }
+
+    if (Number(pageNumber) <= 0) {
+      // example: "/admin/articles"
+      return `${pathname}`;
+    }
+
+    if (Number(pageNumber) > totalPages) {
+      // example: "/admin/articles?page=4"
+      // if there's no more articles, stay in the same page
+      return `${pathname}${params.toString()}`;
+    }
+
+    params.set('page', pageNumber.toString());
+
+    return `${pathname}?${params.toString()}`;
+  };
+
+  return (
+    <nav aria-label="Page navigation" className={styles.pagination}>
+      <ul className={styles.paginationList}>
+        <li>
+          {
+            (currentPage === 1)
+              ? (
+                <span className={styles.paginationPrevDisabled}>
+                  {translate('prev')}
+                </span>
+              ) : (
+                <Link
+                  href={createPageUrl(currentPage - 1)}
+                  className={styles.paginationPrevious}>
+                  {translate('prev')}
+                </Link>
+              )
+          }
+        </li>
+        {allPages.map((page, index) => (
+          <li key={`${page}-${index}`}>
+            <Link
+              href={createPageUrl(page)}
+              className={(page === currentPage)
+                ? styles.paginationCurrentPage
+                : styles.paginationPage
+              }
+            >
+              {page !== '...' ? page : '...'}
+            </Link>
+          </li>
+        ))}
+        <li>
+          {
+            (currentPage === totalPages)
+              ? (
+                <span className={styles.paginationNextDisabled}>
+                  {translate('next')}
+                </span>
+              ) : (
+                <Link
+                  href={createPageUrl(currentPage + 1)}
+                  className={styles.paginationNext}
+                >
+                  {translate('next')}
+                </Link>
+              )
+          }
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default PublicPagination;

--- a/src/app/(public)/components/pagination/styles.module.css
+++ b/src/app/(public)/components/pagination/styles.module.css
@@ -1,0 +1,104 @@
+@reference 'tailwindcss';
+
+.pagination {
+  @apply flex justify-center mt-10;
+}
+
+.paginationList {
+  @apply inline-flex -space-x-px text-sm;
+}
+
+.paginationPrevious {
+  @apply flex items-center justify-center px-3 md:px-4 h-8 md:h-10 ms-0
+    leading-tight
+    text-stone-500
+    bg-stone-50
+    border
+    border-e-0
+    md:rounded-s-lg
+    border-stone-300
+    md:border-stone-300
+    rounded-s-lg
+    hover:bg-stone-100
+    hover:text-stone-700
+    dark:bg-stone-800
+    dark:border-stone-700
+    dark:text-stone-400
+    dark:hover:bg-stone-700
+    dark:hover:text-stone-50;
+}
+
+.paginationPrevDisabled {
+  @apply flex items-center justify-center px-3 md:px-4 h-8 md:h-10
+    leading-tight
+    text-stone-600
+    bg-stone-400
+    border
+    border-stone-300
+    rounded-s-lg
+    md:rounded-s-lg
+    dark:bg-stone-800
+    dark:border-stone-700
+    dark:text-stone-500
+    cursor-not-allowed;
+}
+
+.paginationNext {
+  @apply flex items-center justify-center px-3 md:px-4 h-8 md:h-10
+    leading-tight
+    text-stone-500
+    bg-stone-50
+    border
+    border-stone-300
+    rounded-e-lg
+    hover:bg-stone-100
+    hover:text-stone-700
+    dark:bg-stone-800
+    dark:border-stone-700
+    dark:text-stone-400
+    dark:hover:bg-stone-700
+    dark:hover:text-stone-50
+}
+
+.paginationNextDisabled {
+  @apply flex items-center justify-center px-3 md:px-4 h-8 md:h-10
+    leading-tight
+    text-stone-600
+    bg-stone-400
+    border
+    border-stone-300
+    rounded-e-lg
+    dark:bg-stone-800
+    dark:border-stone-700
+    dark:text-stone-500
+    cursor-not-allowed;
+}
+
+.paginationPage {
+  @apply flex items-center justify-center md:px-4 px-3 h-8 md:h-10
+    leading-tight
+    text-stone-500
+    bg-stone-50
+    border
+    border-stone-300
+    hover:bg-stone-100
+    hover:text-stone-700
+    dark:bg-stone-800
+    dark:border-stone-700
+    dark:text-stone-400
+    dark:hover:bg-stone-700
+    dark:hover:text-stone-50;
+}
+
+.paginationCurrentPage {
+  @apply flex items-center justify-center px-3 md:px-4 h-8 md:h-10
+  text-stone-600
+  border
+  border-stone-300
+  bg-stone-50
+  hover:bg-stone-600
+  hover:text-stone-50
+  dark:border-stone-700
+  dark:bg-stone-700
+  dark:text-white;
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,25 +1,46 @@
-import { type FC, use } from "react";
+import type { FC } from "react";
+import { use } from "react";
 import { useTranslations } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
-import fetchPublicArticlesAction from "@/app/(public)/(actions)/fetch-articles.action";
+import { fetchPublicArticlesAction, ResponseFetchArticles } from "@/app/(public)/(actions)/fetch-articles.action";
 import PublicLayout from "@/app/(public)/public.layout";
 import ArticlesList from "@/app/(public)/components/article-list.component";
 import { MainContainer } from "@/components/main-container.component";
-
-export const dynamic = 'force-dynamic';
+import type { Pagination } from "@/interfaces/pagination.interface";
+import { PublicPagination } from "@/app/(public)/components/pagination/pagination.component";
+import { unstable_cache } from 'next/cache';
 
 type Props = Readonly<{
   params: Promise<{ locale: string }>;
+  searchParams: Promise<{
+    page?: string;
+    take?: string;
+  }>;
 }>;
 
-const HomePage: FC<Props> = ({ params }) => {
+const HomePage: FC<Props> = ({ params, searchParams }) => {
+  const { page, take } = use(searchParams);
   const { locale } = use(params);
-
+  
   // Enable static rendering
   setRequestLocale(locale);
+  
+  const getCachedArticles = unstable_cache(
+    async () => {
+      return fetchPublicArticlesAction({
+        page: page ? parseInt(page) : undefined,
+        take: take ? parseInt(take) : undefined,
+      });
+    },
+    ["public-articles", page, take],
+    {
+      tags: ['public-articles'],
+      revalidate: 86000, // Every 24 hours (24 * 60 * 60)
+    }
+  );
 
-  const response = use(fetchPublicArticlesAction({ limit: 7 }));
-  const articles = response.articles ?? [];
+  const { articles, pagination } = use(getCachedArticles()) as ResponseFetchArticles;
+  const { totalPages } = pagination as Pagination;
 
   // Once the request locale is set, you
   // can call hooks from `next-intl`
@@ -29,7 +50,8 @@ const HomePage: FC<Props> = ({ params }) => {
     <PublicLayout>
       <MainContainer>
         <h1 className="hide-element">{translate('title')}</h1>
-        <ArticlesList articles={articles} locale={locale} />
+        <ArticlesList articles={articles ?? []} locale={locale} />
+        { totalPages > 1 && <PublicPagination totalPages={totalPages} />}
       </MainContainer>
     </PublicLayout>
   );

--- a/src/app/admin/articles/(actions)/create-article.action.ts
+++ b/src/app/admin/articles/(actions)/create-article.action.ts
@@ -3,7 +3,7 @@
 import prisma from "@/lib/prisma";
 
 import { createFormSchema } from "./create-article.schema";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import uploadImage from "./upload-image.action";
 import z from "zod";
 
@@ -118,6 +118,7 @@ export const createArticleAction = async (
     });
 
     // Revalidate Paths
+    revalidateTag('public-articles');
     revalidatePath('/');
     revalidatePath('/admin/articles');
 

--- a/src/app/admin/articles/(actions)/delete-article.action.ts
+++ b/src/app/admin/articles/(actions)/delete-article.action.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import prisma from "@/lib/prisma";
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import deleteImage from "./delete-image.action";
 
 export const deleteArticleAction = async (articleId: string) => {
@@ -32,6 +32,7 @@ export const deleteArticleAction = async (articleId: string) => {
     }
   }
 
+  revalidateTag('public-articles');
   revalidatePath('/admin/articles');
 
   return {

--- a/src/app/admin/articles/(actions)/fetch-articles.action.ts
+++ b/src/app/admin/articles/(actions)/fetch-articles.action.ts
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { Pagination } from "@/interfaces/pagination.interface";
 
 type Options = Readonly<{
   page?: number;
@@ -36,11 +37,6 @@ type ResponseFetchArticles = Promise<{
   articles: AdminArticle[] | null;
   pagination: Pagination | null;
 }>;
-
-export type Pagination = {
-  currentPage: number;
-  totalPages: number;
-};
 
 /**
  * Action to fetch articles from the database.

--- a/src/app/admin/articles/(actions)/update-article-state.action.ts
+++ b/src/app/admin/articles/(actions)/update-article-state.action.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import prisma from "@/lib/prisma";
 
 type UpdateArticleStatusResponse = {
@@ -26,8 +26,9 @@ export const updateArticleStateAction = async (
   await prisma.article.update({
     where: { id: articleId },
     data: { published: !article.published },
-  });
-  
+  });  
+
+  revalidateTag('public-articles');
   revalidatePath('/admin/articles');
 
   return {

--- a/src/app/admin/articles/(actions)/update-article.action.ts
+++ b/src/app/admin/articles/(actions)/update-article.action.ts
@@ -1,6 +1,6 @@
 'use server';
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import editFormSchema from "../../articles/[id]/edit/edit-article.schema";
 import prisma from "@/lib/prisma";
 import { Article } from "@/interfaces/article.interface";
@@ -170,8 +170,10 @@ export const updateArticleAction = async (
           updatedArticle.imageURL = imageUploaded.secureUrl;
         }
 
-        // Revalidate Paths
+        // Revalidate Cache
+        revalidateTag('public-articles');
         revalidatePath('/');
+
         updatedArticle.category?.translations.forEach((categoryTranslation) => {
           updatedArticle.translations.forEach((articleTranslation) => {
             if (articleTranslation.language === categoryTranslation.language) {

--- a/src/app/admin/articles/(components)/articles.component.tsx
+++ b/src/app/admin/articles/(components)/articles.component.tsx
@@ -30,13 +30,12 @@ import { toast } from "sonner";
 import { updateArticleStateAction } from "../(actions)/update-article-state.action";
 import { deleteArticleAction } from "../(actions)/delete-article.action";
 import { getFirstAndLastName } from "@/lib/utils";
-import { AdminArticle, Pagination } from "../(actions)/fetch-articles.action";
+import { AdminArticle } from "../(actions)/fetch-articles.action";
 import Image from "next/image";
 import RobotsBadges from "@/root/src/components/robots-badges.component";
 
 type Props = Readonly<{
   articles: AdminArticle[];
-  pagination: Pagination;
 }>;
 
 export const Articles: FC<Props> = ({ articles }) => {

--- a/src/app/admin/articles/page.tsx
+++ b/src/app/admin/articles/page.tsx
@@ -11,8 +11,9 @@ import {
 } from "@/components/ui/breadcrumb";
 import styles from "./styles.module.css";
 import { Articles } from "./(components)/articles.component";
-import fetchArticlesAction, { Pagination } from "./(actions)/fetch-articles.action";
+import fetchArticlesAction from "./(actions)/fetch-articles.action";
 import { PaginationLinks } from "../(components)/pagination/pagination.component";
+import { Pagination } from "@/interfaces/pagination.interface";
 
 type Props = Readonly<{
   searchParams: Promise<{
@@ -36,7 +37,7 @@ const ArticlesPage: FC<Props> = async ({ searchParams }) => {
     redirect('/admin/articles?page=1');
   }
 
-  const { totalPages, currentPage } = response.pagination as Pagination;
+  const { totalPages } = response.pagination as Pagination;
 
   return (
     <AdminLayout>
@@ -58,10 +59,7 @@ const ArticlesPage: FC<Props> = async ({ searchParams }) => {
         <main>
           <div className={styles.mainWrapper}>
             <div className={styles.section}>
-              <Articles
-                articles={articles}
-                pagination={{ totalPages, currentPage }}
-              />
+              <Articles articles={articles} />
               <PaginationLinks totalPages={totalPages} />
             </div>
           </div>

--- a/src/interfaces/pagination.interface.ts
+++ b/src/interfaces/pagination.interface.ts
@@ -1,0 +1,4 @@
+export type Pagination = {
+  currentPage: number;
+  totalPages: number;
+};


### PR DESCRIPTION
Implements pagination for the public articles list to improve user experience and performance.

- Introduces a new action to fetch articles with pagination options (page, take, category).
- Adds a pagination component with "next" and "previous" buttons.
- Updates translations for "next" and "previous" buttons in English and Spanish.
- Implements caching strategy to improve performance.